### PR TITLE
Change val to def in trait

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -26,7 +26,7 @@ trait MacroCompat {
 
   def TypeName(s: String) = newTypeName(s)
   def TermName(s: String) = newTermName(s)
-  val typeNames = tpnme
+  def typeNames = tpnme
 
   def freshName = c.fresh
   def freshName(name: String) = c.fresh(name)


### PR DESCRIPTION
This change fixes errors like the following in circe (on Scala 2.10 only):

``` scala
[error] /home/travis/code/projects/circe/core/shared/src/main/scala/io/circe/Decoder.scala:460: exception during macro expansion: 
[error] java.lang.AbstractMethodError: export.ExportMacro.macrocompat$MacroCompat$_setter_$typeNames_$eq(Lscala/reflect/api/StandardNames$TypeNamesApi;)V
[error]         at macrocompat.MacroCompat$class.$init$(macrocompat.scala:29)
[error]         at export.ExportMacro.<init>(export.scala:48)
[error]         at export.ExportMacro$.exportedImpl(export.scala:48)
[error] @export.exported[Decoder] trait LowPriorityDecoders
[error]  ^
```
