### PR TITLE
Add support for companion, decls and paramLists

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -61,6 +61,17 @@ trait MacroCompat {
   implicit def mkTypeOps(tpe: Type): TypeOps = new TypeOps(tpe)
   class TypeOps(tpe: Type) {
     def typeParams = tpe.typeSymbol.asType.typeParams
+    def companion = {
+      val compSym = tpe.typeSymbol.companionSymbol
+      if (compSym.isModule) compSym.asModule.moduleClass.asType.toType
+      else NoType
+    }
+    def decls = tpe.declarations
+  }
+
+  implicit def mkMethodSymbolOps(sym: MethodSymbol): MethodSymbolOps = new MethodSymbolOps(sym)
+  class MethodSymbolOps(sym: MethodSymbol) {
+    def paramLists = sym.paramss
   }
 
   def appliedType(tc: Type, ts: List[Type]): Type = c.universe.appliedType(tc, ts)

--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -62,8 +62,9 @@ trait MacroCompat {
   class TypeOps(tpe: Type) {
     def typeParams = tpe.typeSymbol.asType.typeParams
     def companion = {
-      val compSym = tpe.typeSymbol.companionSymbol
-      if (compSym.isModule) compSym.asModule.moduleClass.asType.toType
+      val typSym = tpe.typeSymbol
+      if (typSym.isModuleClass) tpe.termSymbol.companionSymbol.asType.toType
+      else if (typSym.isClass) typSym.companionSymbol.asModule.moduleClass.asType.toType
       else NoType
     }
     def decls = tpe.declarations

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -32,6 +32,8 @@ object Test {
   def bazE(is: Int*): Int = macro TestMacro.bazEImpl
 
   def quux[T](t: T): T = macro TestMacro.quuxImpl[T]
+
+  def comp[T]: String = macro TestMacro.compImpl[T]
 }
 
 @bundle
@@ -70,4 +72,10 @@ class TestMacro(val c: whitebox.Context) {
     val foo = c.typecheck(q""" 1+1 """, c.TYPEmode).tpe
     c.Expr[T](t.tree)
   }
+
+  def compImpl[T: c.WeakTypeTag]: Tree = {
+    val typ = weakTypeOf[T]
+    q""" ${typ.companion.toString } """
+  }
+
 }

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -33,7 +33,7 @@ object Test {
 
   def quux[T](t: T): T = macro TestMacro.quuxImpl[T]
 
-  def comp[T]: String = macro TestMacro.compImpl[T]
+  def comp[T](t: T): String = macro TestMacro.compImpl[T]
 }
 
 @bundle
@@ -73,7 +73,7 @@ class TestMacro(val c: whitebox.Context) {
     c.Expr[T](t.tree)
   }
 
-  def compImpl[T: c.WeakTypeTag]: Tree = {
+  def compImpl[T: c.WeakTypeTag](t: c.Expr[T]): Tree = {
     val typ = weakTypeOf[T]
     q""" ${typ.companion.toString } """
   }

--- a/test/src/test/scala/testmacro/testmacro.scala
+++ b/test/src/test/scala/testmacro/testmacro.scala
@@ -50,8 +50,11 @@ class MacroCompatTests extends FunSuite {
   }
 
   test("Accessing companion") {
-    val res = Test.comp[Foo]
+    val res = Test.comp(new Foo)
     assert(res == "testmacro.Foo.type")
+
+    val res2 = Test.comp(Foo)
+    assert(res2 == "testmacro.Foo")
   }
 }
 

--- a/test/src/test/scala/testmacro/testmacro.scala
+++ b/test/src/test/scala/testmacro/testmacro.scala
@@ -48,4 +48,12 @@ class MacroCompatTests extends FunSuite {
     val res = Test.bazE(1, 2, 3)
     assert(res == 13)
   }
+
+  test("Accessing companion") {
+    val res = Test.comp[Foo]
+    assert(res == "testmacro.Foo.type")
+  }
 }
+
+class Foo
+object Foo


### PR DESCRIPTION
The companion implementation doesn't support going from object -> class, only class -> object, as I haven't yet worked out how to construct a macro that starts from an object and I need to get some sleep.

On the plus side, with this patch, I was able to successfully cross-build Marley(https://github.com/guardian/marley/tree/macro-compat) with this.
