### PR TITLE
Properly handle class/object without companion

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -63,8 +63,10 @@ trait MacroCompat {
     def typeParams = tpe.typeSymbol.asType.typeParams
     def companion = {
       val typSym = tpe.typeSymbol
-      if (typSym.isModuleClass) tpe.termSymbol.companionSymbol.asType.toType
-      else if (typSym.isClass) typSym.companionSymbol.asModule.moduleClass.asType.toType
+      if (typSym.isModuleClass && tpe.termSymbol.companionSymbol.isType)
+        tpe.termSymbol.companionSymbol.asType.toType
+      else if (typSym.isClass && !typSym.isModuleClass && typSym.companionSymbol.isModule)
+        typSym.companionSymbol.asModule.moduleClass.asType.toType
       else NoType
     }
     def decls = tpe.declarations

--- a/test/src/test/scala/testmacro/testmacro.scala
+++ b/test/src/test/scala/testmacro/testmacro.scala
@@ -55,8 +55,18 @@ class MacroCompatTests extends FunSuite {
 
     val res2 = Test.comp(Foo)
     assert(res2 == "testmacro.Foo")
+
+    val res3 = Test.comp(new Bar)
+    assert(res3 == "<notype>")
+
+    val res4 = Test.comp(Baz)
+    assert(res4 == "<notype>")
   }
 }
 
 class Foo
 object Foo
+
+class Bar
+
+object Baz


### PR DESCRIPTION
I found out the reason for some of the extra logic in the 2.11 implementation when my original use-case failed.
