### PR TITLE
More aliases, plus minor fix to existing one

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -56,7 +56,7 @@ trait MacroCompat {
   val termNames = nme
   val typeNames = tpnme
 
-  def freshName = c.fresh
+  def freshName() = c.fresh
   def freshName(name: String) = c.fresh(name)
   def freshName[NameType <: Name](name: NameType) = c.fresh(name)
 

--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -100,6 +100,8 @@ trait MacroCompat {
     def decl(nme: Name): Symbol = tpe.declaration(nme)
 
     def decls = tpe.declarations
+
+    def dealias: Type = tpe.normalize
   }
 
   implicit class MethodSymbolOps(sym: MethodSymbol) {

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -44,6 +44,8 @@ object Test {
   def untypecheck[T](t: T): T = macro TestMacro.untypecheckImpl[T]
 
   def ensureOneTypeArg[T]: Unit = macro TestMacro.ensureOneTypeArgImpl[T]
+
+  def freshName: String = macro TestMacro.freshNameImpl
 }
 
 @bundle
@@ -130,6 +132,11 @@ class TestMacro(val c: whitebox.Context) extends TestUtil {
         s"Cannot dealias ${weakTypeOf[T]} to a type with one type argument"
       )
     }
+
+  def freshNameImpl: Tree = {
+    val name = c.freshName().toString
+    q" $name "
+  }
 
   def useUtil: Tree =
     util(typeOf[Int])

--- a/test/src/test/scala/testmacro/testmacro.scala
+++ b/test/src/test/scala/testmacro/testmacro.scala
@@ -106,6 +106,10 @@ class MacroCompatTests extends FunSuite {
     type T = List[Int]
     Test.ensureOneTypeArg[T]
   }
+
+  test("Fresh name") {
+    Test.freshName
+  }
 }
 
 class Foo

--- a/test/src/test/scala/testmacro/testmacro.scala
+++ b/test/src/test/scala/testmacro/testmacro.scala
@@ -110,6 +110,15 @@ class MacroCompatTests extends FunSuite {
   test("Fresh name") {
     Test.freshName
   }
+
+  test("Annotation") {
+    class Annotation extends scala.annotation.StaticAnnotation
+    @Annotation trait T
+
+    val annTpe = Test.AnnotationType[T]
+    val a = new Annotation
+    val a0: annTpe.Ann = a
+  }
 }
 
 class Foo

--- a/test/src/test/scala/testmacro/testmacro.scala
+++ b/test/src/test/scala/testmacro/testmacro.scala
@@ -101,6 +101,11 @@ class MacroCompatTests extends FunSuite {
     val res = Test.untypecheck(23)
     assert((res: Int) == 23)
   }
+
+  test("Dealias types") {
+    type T = List[Int]
+    Test.ensureOneTypeArg[T]
+  }
 }
 
 class Foo


### PR DESCRIPTION
Adds aliases for `dealias` on `Type` and `tree` on `Annotation`, and allows `freshName` to be called with empty parameter list (like it is with scala 2.11).

Beware that the alias for `tree` on `Annotation` doesn't provide a full `Tree` like in scala 2.11, it only provides the recommended alternatives to deprecated methods on `Annotation`.
