### PR TITLE
Ensure the macro context is not accessed too early

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -55,8 +55,8 @@ trait MacroCompat {
     def unapply(name: TermName): Option[String] = Some(name.toString)
   }
 
-  val termNames = nme
-  val typeNames = tpnme
+  lazy val termNames = nme
+  lazy val typeNames = tpnme
 
   def freshName() = c.fresh
   def freshName(name: String) = c.fresh(name)

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -72,6 +72,22 @@ trait TestUtil {
 class TestMacro(val c: whitebox.Context) extends TestUtil {
   import c.universe._
 
+  /**
+    * If a `NullPointerException` gets raised in this method, it means that the `c` member was
+    * accessed during the initialization of the class / trait by `MacroCompat`, which may not be
+    * possible in practice, if the initialization of `c` is delayed.
+    */
+  def noEarlyAccessTest(): Unit = {
+    val c0: c.type = c
+
+    new TestUtil {
+      val c = c0
+    }
+  }
+
+  noEarlyAccessTest()
+
+
   def fooImpl: Tree = {
     val nme0 = TermName(c.freshName)
     val TermName(str0) = nme0


### PR DESCRIPTION
This PR adds a non-regression test and small fixes to ensure the macro context `c` isn't accessed too early when a class which `@bundle` was applied to is instantiated. (See the added test, which crashes without the fixes, and the comment along the added test method.)
