### PR TITLE
Add (empty) decorators object to internal

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -197,5 +197,7 @@ trait MacroCompat {
       def mkAttributedRef(pre: Type, sym: Symbol): Tree =
         global.gen.mkAttributedRef(pre, sym)
     }
+
+    object decorators
   }
 }


### PR DESCRIPTION
Seems in 2.11 some methods are now nested in internal.decorators. So in order to write cross-version macro code
you import decorators, which is empty in 2.10 with this.
