### PR TITLE
Introduce ImplicitCandidate, allows for .pre & .sym

### DIFF
--- a/add-ImplicitCandidate.markdown
+++ b/add-ImplicitCandidate.markdown
@@ -1,0 +1,3 @@
+* Added ImplicitCandidate (thanks to [@dwijnand][]).
+
+[@dwijnand]: http://github.com/dwijnand

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,8 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
     // (these only break forward compatibility, not the backward one)
     Seq(
       ProblemFilters.exclude[MissingMethodProblem]("macrocompat.MacroCompat.TreeOps"),
-      ProblemFilters.exclude[MissingMethodProblem]("macrocompat.MacroCompat.ImplicitCandidateTupleOps")
+      ProblemFilters.exclude[MissingMethodProblem]("macrocompat.MacroCompat.tupleToImplicitCandidate"),
+      ProblemFilters.exclude[MissingMethodProblem]("macrocompat.MacroCompat.ImplicitCandidate")
     )
   }
 )

--- a/notes/1.1.1/add-ImplicitCandidateTupleOps.markdown
+++ b/notes/1.1.1/add-ImplicitCandidateTupleOps.markdown
@@ -1,3 +1,0 @@
-* Added ImplicitCandidateTupleOps (thanks to [@dwijnand][]).
-
-[@dwijnand]: http://github.com/dwijnand


### PR DESCRIPTION
This doesn't solve the import problem, but it allows c.openImplicits in 2.10 code to work, by later enriching the returned value to have .pre & .sym properties, at a computation cost (filtering everytime..).

It's an improvement on the #28, but it doesn't solve #22.
