### PR TITLE
Cross build for 2.12.0-M3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: scala
 scala:
 - 2.11.7
 - 2.10.6
+- 2.12.0-M3
 
 jdk:
 - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ class TestMacro(val c: whitebox.Context) {
 }
 ```
 
-This code compiles on both Scala 2.11.x and 2.10.x.
+This code compiles on Scala 2.10.x, 2.11.x and 2.12.x.
 
 The `@bundle` annotation is implemented as a macro annotation via the [macro-paradise][macro-paradise] compiler
-plugin. On Scala 2.11.x the annotation is simply eliminated during compilation, leaving no trace in the resulting
-binaries. On Scala 2.10.x the annotation macro transforms the macro bundle class to an object definition which is
-compatible with the 2.10.x macro API.
+plugin. On Scala 2.11.x and 2.12.x the annotation is simply eliminated during compilation, leaving no trace in the
+resulting binaries. On Scala 2.10.x the annotation macro transforms the macro bundle class to an object definition
+which is compatible with the 2.10.x macro API.
 
 ## Current status
 
@@ -99,7 +99,7 @@ resolvers ++= Seq(
 )
 ```
 
-Builds are available for Scala 2.11.x and 2.10.x for Scala JDK and Scala.js.
+Builds are available for Scala 2.10.x, 2.11.x and 2.12.x for Scala JDK and Scala.js.
 
 ```scala
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 lazy val buildSettings = Seq(
   organization := "org.typelevel",
   scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.6", "2.11.7")
+  crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.0-M3")
 )
 
 lazy val commonSettings = Seq(
@@ -68,8 +68,8 @@ lazy val test = crossProject.crossType(CrossType.Pure)
   .settings(noPublishSettings:_*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scalatest"  %%% "scalatest"  % "3.0.0-M7" % "test",
-      "org.scalacheck" %%% "scalacheck" % "1.12.4"   % "test"
+      "org.scalatest"  %%% "scalatest"  % "3.0.0-M12" % "test",
+      "org.scalacheck" %%% "scalacheck" % "1.12.5"    % "test"
     )
   )
   .jsSettings(commonJsSettings:_*)

--- a/core/src/main/scala_2.12.0-M3/macrocompat/bundle_2.12.scala
+++ b/core/src/main/scala_2.12.0-M3/macrocompat/bundle_2.12.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package macrocompat
+
+import scala.language.experimental.macros
+
+import scala.annotation.StaticAnnotation
+
+import scala.reflect.macros.blackbox
+
+class bundle extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro BundleMacro.bundleImpl
+}
+
+class BundleMacro(val c: blackbox.Context) {
+  import c.universe._
+
+  def bundleImpl(annottees: Tree*): Tree = {
+    q""" ..$annottees """
+  }
+}

--- a/notes/1.2.0/add-Scala-2.12.markdown
+++ b/notes/1.2.0/add-Scala-2.12.markdown
@@ -1,0 +1,3 @@
+* Added 2.12.0-M3 to the cross build version list (thanks to [@dwijnand][])
+
+[@dwijnand]: http://github.com/dwijnand

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release"            % "1.0.0")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"                % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"                % "0.8.4")
-addSbtPlugin("org.scala-js"      % "sbt-scalajs"            % "0.6.4")
+addSbtPlugin("org.scala-js"      % "sbt-scalajs"            % "0.6.5")
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin"        % "0.1.7")


### PR DESCRIPTION
- this required bumping to newer versions of the test libraries
- which required bumping the version of Scala.js
- also need to duplicate bundle_2.11.scala for 2.12
- and the scalaBinaryVersion for 2.12.0-M3 is 2.12.0-M3 (not 2.12)
