### PR TITLE
Handle TypeRef in TypeOps.typeParams

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/macrocompat.scala
+++ b/core/src/main/scala_2.10/macrocompat/macrocompat.scala
@@ -180,7 +180,10 @@ trait MacroCompat {
   lazy val typeNames = tpnme
 
   implicit class TypeOps(tpe: Type) {
-    def typeParams = tpe.typeSymbol.asType.typeParams
+    def typeParams = tpe match {
+      case TypeRef(_, sym, _) => sym.asType.typeParams
+      case _ => tpe.typeSymbol.asType.typeParams
+    }
 
     def typeArgs: List[Type] = tpe match {
       case TypeRef(_, _, args) => args

--- a/notes/1.2.0/handle-TypeRef-in-Type.typeParams.markdown
+++ b/notes/1.2.0/handle-TypeRef-in-Type.typeParams.markdown
@@ -1,0 +1,3 @@
+* Handle TypeRef in Type.typeParams (thanks to [@dwijnand][]).
+
+[@dwijnand]: http://github.com/dwijnand


### PR DESCRIPTION
Discovered when trying to port shapeless to macro-compat.

The fact that this nicely mirrors TypeOps.typeArgs increases my confidence.
