### PR TITLE
Don't generate companion objects for annotated traits

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
+++ b/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
@@ -213,25 +213,11 @@ class BundleMacro[C <: Context](val c: C) {
 
     // There should be a better way of doing this, but it doesn't seem to be possible
     // to abstract over class vs. trait in a quasiquote.
-    val res =
+    val macroClass =
       if(mods.hasFlag(TRAIT))
         q"""
           $mods trait $macroClassNme[..$tparams] extends ..$parents { $self =>
             ..$macroBody
-          }
-
-          object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
-            ..$objBody
-          }
-        """
-      else if(mods0.hasFlag(ABSTRACT))
-        q"""
-          $mods class $macroClassNme[..$tparams] extends ..$parents { $self =>
-            ..$macroBody
-          }
-
-          object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
-            ..$objBody
           }
         """
       else
@@ -239,7 +225,17 @@ class BundleMacro[C <: Context](val c: C) {
           $mods class $macroClassNme[..$tparams] extends ..$parents { $self =>
             ..$macroBody
           }
+        """
 
+    val macroObject =
+      if(mods0.hasFlag(ABSTRACT))
+        q"""
+          object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
+            ..$objBody
+          }
+        """
+      else
+        q"""
           object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
             class $instClass[C0 <: _root_.scala.reflect.macros.Context](val c: _root_.macrocompat.CompatContext[C0]) extends $macroClassNme {
               type C = C0
@@ -252,6 +248,13 @@ class BundleMacro[C <: Context](val c: C) {
             ..$objBody
           }
         """
+
+    val res =
+      q"""
+        $macroClass
+
+        $macroObject
+      """
 
     fixPositions(res)
   }

--- a/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
+++ b/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
@@ -167,7 +167,7 @@ class BundleMacro[C <: Context](val c: C) {
       case None => (Nil, List(tq"_root_.scala.AnyRef"), Nil)
     }
 
-    val mods = Modifiers(mods0.flags|ABSTRACT)
+    val mods = Modifiers(mods0.flags|ABSTRACT, mods0.privateWithin, mods0.annotations)
 
     val defns = body collect {
       case MacroImpl(d: DefDef) => d

--- a/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
+++ b/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
@@ -213,7 +213,7 @@ class BundleMacro[C <: Context](val c: C) {
 
     // There should be a better way of doing this, but it doesn't seem to be possible
     // to abstract over class vs. trait in a quasiquote.
-    val macroClass =
+    val res =
       if(mods.hasFlag(TRAIT))
         q"""
           $mods trait $macroClassNme[..$tparams] extends ..$parents { $self =>
@@ -225,29 +225,19 @@ class BundleMacro[C <: Context](val c: C) {
           $mods class $macroClassNme[..$tparams] extends ..$parents { $self =>
             ..$macroBody
           }
-        """
 
-    val macroObject =
-      q"""
-        object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
-          class $instClass[C0 <: _root_.scala.reflect.macros.Context](val c: _root_.macrocompat.CompatContext[C0]) extends $macroClassNme {
-            type C = C0
+          object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
+            class $instClass[C0 <: _root_.scala.reflect.macros.Context](val c: _root_.macrocompat.CompatContext[C0]) extends $macroClassNme {
+              type C = C0
+            }
+            def $instNme[C <: _root_.scala.reflect.macros.Context](c1: _root_.macrocompat.CompatContext[C]): $instClass[C] =
+              new $instClass[C](c1)
+
+            ..$forwarders
+
+            ..$objBody
           }
-          def $instNme[C <: _root_.scala.reflect.macros.Context](c1: _root_.macrocompat.CompatContext[C]): $instClass[C] =
-            new $instClass[C](c1)
-
-          ..$forwarders
-
-          ..$objBody
-        }
-      """
-
-    val res =
-      q"""
-        $macroClass
-
-        $macroObject
-      """
+        """
 
     fixPositions(res)
   }

--- a/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
+++ b/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
@@ -220,6 +220,12 @@ class BundleMacro[C <: Context](val c: C) {
             ..$macroBody
           }
         """
+      else if(mods0.hasFlag(ABSTRACT))
+        q"""
+          $mods class $macroClassNme[..$tparams] extends ..$parents { $self =>
+            ..$macroBody
+          }
+        """
       else
         q"""
           $mods class $macroClassNme[..$tparams] extends ..$parents { $self =>

--- a/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
+++ b/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
@@ -219,11 +219,19 @@ class BundleMacro[C <: Context](val c: C) {
           $mods trait $macroClassNme[..$tparams] extends ..$parents { $self =>
             ..$macroBody
           }
+
+          object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
+            ..$objBody
+          }
         """
       else if(mods0.hasFlag(ABSTRACT))
         q"""
           $mods class $macroClassNme[..$tparams] extends ..$parents { $self =>
             ..$macroBody
+          }
+
+          object $macroObjectNme extends { ..$objEarlydefns } with ..$objParents {
+            ..$objBody
           }
         """
       else

--- a/test/src/main/scala/testmacro/companionobject.scala
+++ b/test/src/main/scala/testmacro/companionobject.scala
@@ -38,7 +38,7 @@ trait ClassWithCompanionObjectMixin {
 @macrocompat.bundle
 class ClassWithCompanionObjectWithMixin(val c: whitebox.Context)
 
-object ClassWithCompanionObjectWithMixin extends ClassWithCompanionObjectMixin {
+object ClassWithCompanionObjectWithMixin extends AnyRef with ClassWithCompanionObjectMixin {
   def foo = 1
 }
 

--- a/test/src/main/scala/testmacro/override.scala
+++ b/test/src/main/scala/testmacro/override.scala
@@ -36,7 +36,7 @@ trait Super0 {
 }
 
 @bundle
-class Sub0(val c: whitebox.Context) extends Super0 {
+class Sub0(val c: whitebox.Context) extends AnyRef with Super0 {
   import c.universe._
 
   def barImpl(i: Tree): Tree = q""" "bar" """

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -74,6 +74,12 @@ abstract class TestMacroBase {
   import c.universe._
 
   def abstractClassAbstractMethod: Tree
+
+  def abstractClassMethodUsingCompanionObject: Tree = q"${TestMacroBase.foo}"
+}
+
+object TestMacroBase {
+  def foo = 1
 }
 
 @bundle
@@ -86,6 +92,12 @@ trait TestUtil {
   }
 
   def traitAbstractMethod: Tree
+
+  def traitMethodUsingCompanionObject: Tree = q"${TestUtil.foo}"
+}
+
+object TestUtil {
+  def foo = 1
 }
 
 @bundle

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -69,6 +69,14 @@ object Test {
 }
 
 @bundle
+abstract class TestMacroBase {
+  val c: whitebox.Context
+  import c.universe._
+
+  def abstractClassAbstractMethod: Tree
+}
+
+@bundle
 trait TestUtil {
   val c: whitebox.Context
   import c.universe._
@@ -81,7 +89,7 @@ trait TestUtil {
 }
 
 @bundle
-class TestMacro(val c: whitebox.Context) extends AnyRef with TestUtil {
+class TestMacro(val c: whitebox.Context) extends TestMacroBase with TestUtil {
   import c.universe._
 
   // Test for early use of context
@@ -216,4 +224,6 @@ class TestMacro(val c: whitebox.Context) extends AnyRef with TestUtil {
   }
 
   def traitAbstractMethod: Tree = q"()"
+
+  def abstractClassAbstractMethod: Tree = q"()"
 }

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -76,6 +76,8 @@ trait TestUtil {
   def util(t: Type): Tree = {
     q""" () """
   }
+
+  def traitAbstractMethod: Tree
 }
 
 @bundle
@@ -212,4 +214,6 @@ class TestMacro(val c: whitebox.Context) extends AnyRef with TestUtil {
     val tree = i.tree.toString
     q"($pre, $sym, $pt, $tree)"
   }
+
+  def traitAbstractMethod: Tree = q"()"
 }


### PR DESCRIPTION
Traits can have abstract methods (for example IsCons1Macros in shapeless).

Thus it's not possible to generally define (& provide a constructing
methods of) a concrete subclass of the macro bundle.

---

I'm not sure if we wan't to be more fancy here, but this solves the problem for now.
