### PR TITLE
Add implicit to allow basic reporter use in 2.10

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
+++ b/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
@@ -205,6 +205,7 @@ class BundleMacro[C <: Context](val c: C) {
         val c: _root_.macrocompat.CompatContext[C]
 
         import c.compatUniverse._
+        import _root_.macrocompat.TypecheckerContextExtensions._
 
         private def appliedType(tc: c.universe.Type, ts: _root_.scala.collection.immutable.List[c.universe.Type]): c.universe.Type = c.universe.appliedType(tc, ts)
 

--- a/core/src/main/scala_2.10/macrocompat/contextreporter.scala
+++ b/core/src/main/scala_2.10/macrocompat/contextreporter.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package macrocompat
+
+class ContextReporter[
+  C <: tools.nsc.typechecker.Contexts#Context
+](val c: C) {
+  def hasErrors = c.hasErrors
+  def isBuffering = c.bufferErrors
+  def isThrowing = c.throwErrors
+  def errors = c.errBuffer.toVector
+  def warnings = c.warningsBuffer.toVector
+  def firstError = errors.headOption
+  def clearAll(): Unit = {
+    c.errBuffer.clear
+    c.warningsBuffer.clear
+  }
+  def clearAllErrors(): Unit = c.errBuffer.clear
+}
+class TypecheckerContextExtensions[
+  C <: tools.nsc.typechecker.Contexts#Context
+](val c: C) {
+  def reporter = new ContextReporter[C](c)
+}
+
+object TypecheckerContextExtensions {
+  implicit def contextExtensions[C <: tools.nsc.typechecker.Contexts#Context](c: C) =
+    new TypecheckerContextExtensions[C](c)
+}

--- a/test/src/main/scala/testmacro/reporter.scala
+++ b/test/src/main/scala/testmacro/reporter.scala
@@ -1,0 +1,33 @@
+
+/*
+ * Copyright (c) 2015 Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reporters
+
+import scala.reflect.macros.whitebox
+
+@macrocompat.bundle
+class ErrorReporterMacro(val c: whitebox.Context) {
+  import c.universe._
+  def testReporterImplicit(t: Tree): Tree = {
+    val casted = c.asInstanceOf[reflect.macros.runtime.Context]
+    val typer = casted.callsiteTyper
+    val ctx = typer.context
+    val r = ctx.reporter
+    r.errors.map(_.errMsg)
+    t
+  }
+}


### PR DESCRIPTION
This ports some of the "ContextReporter" API from 2.11+ back to 2.10 (enough that you can at least get at errors in a common way).
