### PR TITLE
Make 2.10.6 the default scalaVersion

### DIFF
--- a/.sbtrc
+++ b/.sbtrc
@@ -1,1 +1,1 @@
-alias boot = ;reload ;project testJVM ;++2.10.6 ;iflast shell
+alias boot = ;reload ;project testJVM ;iflast shell

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 lazy val buildSettings = Seq(
   organization := "org.typelevel",
-  scalaVersion := "2.11.7",
+  scalaVersion := "2.10.6",
   crossScalaVersions := Seq("2.10.6", "2.11.7", "2.12.0-M3")
 )
 


### PR DESCRIPTION
By changing this and removing the switch in .sbtrc hopefully the local development convenience is maintained and the community build issue in scala/community-builds#202 is fixed.

/cc @InTheNow who initially setup .sbtrc
/cc @SethTisue
