### PR TITLE
Fixed invalid pattern matching on WeakTypeTag

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
+++ b/core/src/main/scala_2.10/macrocompat/bundle_2.10.scala
@@ -135,7 +135,7 @@ class BundleMacro[C <: Context](val c: C) {
         case TreeE(_)|ExprE(_)
           if vparamss.forall(_.forall {
             case ValDef(mods, _, _, _) if mods hasFlag IMPLICIT => true
-            case ValDef(_, _, TreeE(_)|ExprE(_)|Repeat(TreeE(_))|Repeat(ExprE(_))|WeakTypeTag(_), _) => true
+            case ValDef(_, _, TreeE(_)|ExprE(_)|Repeat(TreeE(_))|Repeat(ExprE(_))|WeakTypeTagE(_), _) => true
             case _ => false
           }) => Some(d)
         case _ => None

--- a/test/src/main/scala/testmacro/testmacro.scala
+++ b/test/src/main/scala/testmacro/testmacro.scala
@@ -37,6 +37,8 @@ object Test {
 
   def quux[T](t: T): T = macro TestMacro.quuxImpl[T]
 
+  def quuxExplicit[T](t: T): T = macro TestMacro.quuxExplicitImpl[T]
+
   def comp[T](t: T): String = macro TestMacro.compImpl[T]
 
   def symbolOf[T](t: T): String = macro TestMacro.symbolOfImpl[T]
@@ -137,6 +139,8 @@ class TestMacro(val c: whitebox.Context) extends TestMacroBase with TestUtil {
   def bazImpl(is: Tree*): Tree = q""" 13 """
 
   def quuxImpl[T: WeakTypeTag](t: Tree): Tree = t
+
+  def quuxExplicitImpl[T](t: Tree)(T: WeakTypeTag[T]): Tree = t
 
   def fooEImpl: c.Expr[Int] = c.Expr[Int](q""" 23 """)
 

--- a/test/src/test/scala/testmacro/testmacro.scala
+++ b/test/src/test/scala/testmacro/testmacro.scala
@@ -34,6 +34,16 @@ class MacroCompatTests extends FunSuite {
     assert(res == 13)
   }
 
+  test("Generic method, implicit WeakTypeTag") {
+    val res = Test.quux( "foo" )
+    assert(res == "foo")
+  }
+
+  test("Generic method, explicit WeakTypeTag") {
+    val res = Test.quuxExplicit( "foo" )
+    assert(res == "foo")
+  }
+
   test("No arg method, Expr") {
     val res = Test.fooE
     assert(res == 23)


### PR DESCRIPTION
The MacroImpl extractor was matching against WeakTypeTag instead of
WeakTypeTagE, causing any macro def implementation that takes a
non-implicit WeakTypeTag to miss its forwarder (because the match
fails, when it should succeed). The fix is one character long, should be an 
easy merge :-)

It might seem weird to take a WeakTypeTag as a non-implicit parameter, 
but if it is supported by the scala compiler there is no good reason to break
it.
In addition, the current pattern matching (against WeakTypeTag 
instead of WeakTypeTagE) can only happen for non-implicit parameters 
already, so in any case it should either be removed altogether (removing 
support for non-implicit WeakTypeTag parameters), or be made consistent 
with the rest of the code (changing `WeakTypeTag(_)` into 
`WeakTypeTagE(_)` (which is the full extent of what this PR does).
