### PR TITLE
Documentation improvement suggested in #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ object Test {
 class TestMacro(val c: whitebox.Context) {
   import c.universe._
 
-  def fooImpl: Tree = q""" 23 """
+  def fooImpl: Tree = q""" 23 """ // explicit return type : Tree required
 
   def barImpl(i: Tree): Tree = q""" "bar" """
 


### PR DESCRIPTION
This makes it more explicit that the result type is indeed required, not just put there for demonstration reasons.
