### PR TITLE
Fidelity improvements

### DIFF
--- a/core/src/main/scala_2.10/macrocompat/compatcontext.scala
+++ b/core/src/main/scala_2.10/macrocompat/compatcontext.scala
@@ -346,7 +346,7 @@ class RuntimeCompatContext(val c: RuntimeContext) extends RuntimeContext with Co
 
         def isConstructor: Boolean = sym.isMethod &&sym.asMethod.isConstructor
 
-        def isAbstract: Boolean = sym.isAbstractClass
+        def isAbstract: Boolean = sym.isAbstractClass || sym.isDeferred || sym.isAbstractType
 
         def overrides: List[Symbol] = sym.allOverriddenSymbols
 

--- a/core/src/main/scala_2.10/macrocompat/compatcontext.scala
+++ b/core/src/main/scala_2.10/macrocompat/compatcontext.scala
@@ -275,10 +275,7 @@ class RuntimeCompatContext(val c: RuntimeContext) extends RuntimeContext with Co
 
     implicit def TypeOps(tpe: Type): TypeOps =
       new TypeOps {
-        def typeParams = tpe match {
-          case TypeRef(_, sym, _) => sym.asType.typeParams
-          case _ => tpe.typeSymbol.asType.typeParams
-        }
+        def typeParams = tpe.typeParams
 
         def typeArgs: List[Type] = {
           import scala.language.reflectiveCalls


### PR DESCRIPTION
This does two things to improve fidelity:

* Switches to using the same set of tests for `isAbstract` as `scala-reflect`: https://github.com/scala/scala/blob/b9d4089d19ead36d07c2d6cdda283c9b678d515e/src/reflect/scala/reflect/internal/Symbols.scala#L109
* Delegates to the compiler's implementation of `typeParams`. What's in `macro-compat` now errors when called on some types. This pass-through implementation to the internal-in-2.10 `typeParams` method doesn't have that problem and I think it gives better fidelity with later versions of Scala. @dwijnand since you contributed this version, I'll ask: Are you fine with this implementation, so long as it doesn't break shapeless?